### PR TITLE
Discrete-time model must inherit DISCRETE TIME to MPC/MHE #89

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ documentation/source/api/
 documentation/source/release_notes.md
 
 documentation/source/example_gallery/.ipynb_checkpoints/
+examples/conti_discrete/main.py

--- a/do_mpc/controller.py
+++ b/do_mpc/controller.py
@@ -118,7 +118,7 @@ class MPC(do_mpc.optimizer.Optimizer, do_mpc.model.IteratedVariables):
         self.n_robust = 0
         self.open_loop = False
         self.use_terminal_bounds = True
-        #self.state_discretization = 'collocation'  #Set in optimizer
+        self.state_discretization = 'collocation'
         self.collocation_type = 'radau'
         self.collocation_deg = 2
         self.collocation_ni = 1

--- a/do_mpc/controller.py
+++ b/do_mpc/controller.py
@@ -113,12 +113,12 @@ class MPC(do_mpc.optimizer.Optimizer, do_mpc.model.IteratedVariables):
             'store_solver_stats',
             'nlpsol_opts'
         ]
-
+        
         # Default Parameters (param. details in set_param method):
         self.n_robust = 0
         self.open_loop = False
         self.use_terminal_bounds = True
-        self.state_discretization = 'collocation'
+        #self.state_discretization = 'collocation'  #Set in optimizer
         self.collocation_type = 'radau'
         self.collocation_deg = 2
         self.collocation_ni = 1
@@ -867,7 +867,7 @@ class MPC(do_mpc.optimizer.Optimizer, do_mpc.model.IteratedVariables):
         elif isinstance(x0, structure3.DMStruct):
             x0 = x0.cat
         else:
-            raise Exception('Invalid type {} for x0. Must be {}'.format(type(x0), (np.ndarray, casadi.DM, structre3.DMStruct)))
+            raise Exception('Invalid type {} for x0. Must be {}'.format(type(x0), (np.ndarray, casadi.DM, structure3.DMStruct)))
 
         # Check input shape.
         n_val = np.prod(x0.shape)

--- a/do_mpc/estimator.py
+++ b/do_mpc/estimator.py
@@ -174,7 +174,7 @@ class MHE(do_mpc.optimizer.Optimizer, Estimator):
 
         # Default Parameters:
         self.meas_from_data = False
-        self.state_discretization = 'collocation'
+        #self.state_discretization = 'collocation'   #Set in optimizer
         self.collocation_type = 'radau'
         self.collocation_deg = 2
         self.collocation_ni = 1
@@ -911,7 +911,7 @@ class MHE(do_mpc.optimizer.Optimizer, Estimator):
         elif isinstance(y0, structure3.DMStruct):
             y0 = y0.cat
         else:
-            raise Exception('Invalid type {} for y0. Must be {}'.format(type(y0), (np.ndarray, casadi.DM, structre3.DMStruct)))
+            raise Exception('Invalid type {} for y0. Must be {}'.format(type(y0), (np.ndarray, casadi.DM, structure3.DMStruct)))
 
         # Check input shape.
         n_val = np.prod(y0.shape)

--- a/do_mpc/estimator.py
+++ b/do_mpc/estimator.py
@@ -174,7 +174,7 @@ class MHE(do_mpc.optimizer.Optimizer, Estimator):
 
         # Default Parameters:
         self.meas_from_data = False
-        #self.state_discretization = 'collocation'   #Set in optimizer
+        self.state_discretization = 'collocation'
         self.collocation_type = 'radau'
         self.collocation_deg = 2
         self.collocation_ni = 1

--- a/do_mpc/model.py
+++ b/do_mpc/model.py
@@ -271,15 +271,11 @@ class Model:
         # Define private class attributes
 
         self._x = []
-
         self._u =   [entry('default', shape=(0,0))]
-
         self._z =   [entry('default', shape=(0,0))]
-
         self._p =   [entry('default', shape=(0,0))]
-
         self._tvp = [entry('default', shape=(0,0))]
-
+        
         self._aux = [entry('default', shape=(1,1))]
         self._aux_expression = [entry('default', expr=DM(0))]
 
@@ -291,9 +287,8 @@ class Model:
         # Measurement noise
         self._v = [entry('default', shape=(0,0))]
 
-
         self.model_type = model_type
-        self.symvar_type = 'SX'
+        self.symvar_type = 'SX' 
 
         self.rhs_list = []
         self.alg_list = [entry('default', expr=[])]
@@ -973,7 +968,7 @@ class Model:
         self._x = _x = struct_symSX(self._x)
         self._w = _w = struct_symSX(self._w)
         self._v = _v = struct_symSX(self._v)
-        self._u = _u =  struct_symSX(self._u)
+        self._u = _u = struct_symSX(self._u)
         self._z = _z = struct_symSX(self._z)
         self._p = _p = struct_symSX(self._p)
         self._tvp = _tvp =  struct_symSX(self._tvp)

--- a/do_mpc/model.py
+++ b/do_mpc/model.py
@@ -631,9 +631,9 @@ class Model:
         """
         return self._getvar('_w')
 
-        @w.setter
-        def w(self, val):
-            raise Exception('Cannot set process noise directly.')
+    @w.setter
+    def w(self, val):
+        raise Exception('Cannot set process noise directly.')
 
 
     @property
@@ -661,9 +661,9 @@ class Model:
         """
         return self._getvar('_v')
 
-        @v.setter
-        def v(self, val):
-            raise Exception('Cannot set measurement noise directly.')
+    @v.setter
+    def v(self, val):
+        raise Exception('Cannot set measurement noise directly.')
 
 
     def set_variable(self, var_type, var_name, shape=(1,1)):

--- a/do_mpc/optimizer.py
+++ b/do_mpc/optimizer.py
@@ -71,6 +71,11 @@ class Optimizer:
             {'slack_name': 'default', 'var':SX.sym('default',(0,0)), 'ub': DM()}
         ]
         self.slack_cost = 0
+        
+        if self.model.model_type == 'continuous':
+            self.state_discretization = 'collocation'
+        else:
+            self.state_discretization = 'discrete'
 
 
     @IndexedProperty


### PR DESCRIPTION
The default value of the self.state_discretization attribute is now set in the optimizer code and inherited from the MPC and MHE object. Moreover, the default value is correctly chosen for discrete systems.

Fixed typos in MPC and MHE code (structure3.DMStruct was incorrectly written as structre3.DMStruct and would throw an error during when raising the exception