### PR TITLE
default u0 value, stored measurement and consistency update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,11 @@ documentation/source/api/
 documentation/source/release_notes.md
 
 documentation/source/example_gallery/.ipynb_checkpoints/
+<<<<<<< Updated upstream
+=======
+examples/conti_discrete/main.py
+examples/chua_circuit/template_simulator.py
+examples/chua_circuit/template_model.py
+examples/chua_circuit/template_mhe.py
+examples/chua_circuit/main.py
+>>>>>>> Stashed changes

--- a/do_mpc/data.py
+++ b/do_mpc/data.py
@@ -66,7 +66,6 @@ class Data:
             '_p':    model.n_p,
             '_aux':  model.n_aux,
         }
-
         self.init_storage()
         self.meta_data = {}
 

--- a/do_mpc/model.py
+++ b/do_mpc/model.py
@@ -1014,7 +1014,7 @@ class Model:
         # Create and store some information about the model regarding number of variables for
         # _x, _y, _u, _z, _tvp, _p, _aux
         self.n_x = self._x.shape[0]
-        self.n_y = self._y.shape[0]
+        self.n_y = self._y_expression.shape[0]
         self.n_u = self._u.shape[0]
         self.n_z = self._z.shape[0]
         self.n_tvp = self._tvp.shape[0]


### PR DESCRIPTION
make_step can now be called without input (previous input is held constant)
Updated documentation. Removed redundant assertions (probably copied twice?)
Measurement now refers to the current (and not next) time step, making it consistent with the definition in the do-mpc doc. The measurement is also stored in the simulator data structure. 
Addresses  #88 and #132 (in part)