### PR TITLE
Fixes #138

### DIFF
--- a/do_mpc/model.py
+++ b/do_mpc/model.py
@@ -1014,7 +1014,7 @@ class Model:
         # Create and store some information about the model regarding number of variables for
         # _x, _y, _u, _z, _tvp, _p, _aux
         self.n_x = self._x.shape[0]
-        self.n_y = self._y.shape[0]
+        self.n_y = self._y_expression.shape[0]
         self.n_u = self._u.shape[0]
         self.n_z = self._z.shape[0]
         self.n_tvp = self._tvp.shape[0]

--- a/do_mpc/model.py
+++ b/do_mpc/model.py
@@ -986,9 +986,10 @@ class Model:
         # Check if it is an empty list (no user input)
         if not self._y_expression:
             self._y_expression = self._x
+            self._y = self._x
         else:
             self._y_expression = struct_SX(self._y_expression)
-        self._y = struct_symSX(self._y)
+            self._y = struct_symSX(self._y)
 
         # Create alg equations:
         self._alg = struct_SX(self.alg_list)
@@ -1014,7 +1015,7 @@ class Model:
         # Create and store some information about the model regarding number of variables for
         # _x, _y, _u, _z, _tvp, _p, _aux
         self.n_x = self._x.shape[0]
-        self.n_y = self._y_expression.shape[0]
+        self.n_y = self._y.shape[0]
         self.n_u = self._u.shape[0]
         self.n_z = self._z.shape[0]
         self.n_tvp = self._tvp.shape[0]

--- a/do_mpc/simulator.py
+++ b/do_mpc/simulator.py
@@ -510,6 +510,7 @@ class Simulator(do_mpc.model.IteratedVariables):
         self.data.update(_z = z0)
         self.data.update(_tvp = tvp0)
         self.data.update(_p = p0)
+        self.data.update(_y = y_next)
         self.data.update(_aux = aux0)
         self.data.update(_time = t0)
 


### PR DESCRIPTION
The future measurement y_meas is now stored in Simulator.data["_y"] when Simulator.make_step(u0) is called. 
Fixed a bug that prevented this from working when the measurements were not explicitly defined in the model with Model.set_meas()

**Yet to be addressed**
1. When the model is setup without measurements, the **_y_expression** structure is copied from self._x (which in turn is a struct_symSX structure). On the other hand, if the measurements are defined, the _y_expression structure is finalized as a struct_SX.
2. When the model is setup the **_y** structure is finalized as a struct_symSX from the list of entries _y. If the measurements were not defined by Model.set_meas(), this list is empty, and so is the resulting structure. This causes the MHE to fail due to upper/lower bounds being initialized incorrectly.
3. Fix a consistency issue where the output of the simulator called at step k is y[k] = g(x[k+1],u[k]). Changing this breaks the examples, because 1 sample delay is introduced