### PR TITLE
Fix for #264 and documentation

### DIFF
--- a/do_mpc/model.py
+++ b/do_mpc/model.py
@@ -639,7 +639,7 @@ class Model:
 
             :raises assertion: Cannot set aux direcly. Use set_expression instead.
         """
-        return self._getvar('_aux_expression')
+        return self._getvar('_aux')
 
     @aux.setter
     def aux(self, val):

--- a/do_mpc/model.py
+++ b/do_mpc/model.py
@@ -371,6 +371,10 @@ class Model:
         else:
             # Before calling setup the attributes _x,_u,_z etc. are dicts with the keys: name and var.
             sym_dict = getattr(self, var_name)
+            if var_name == '_aux_expression':  # or possibly '_aux, depending on what is called in the getter
+                # create the required dict from what is currently a 
+                sym_dict = {'name':[entry.name for entry in sym_dict], 
+                            'var': [entry.expr for entry in sym_dict]}
             # We use the same method as in setup to create symbolic structures from these dicts
             sym_struct = self._convert2struct(sym_dict)
             # We then create a mutable structure of the same structure
@@ -639,7 +643,7 @@ class Model:
 
             :raises assertion: Cannot set aux directly Use set_expression instead.
         """
-        return self._getvar('_aux')
+        return self._getvar('_aux_expression')
 
     @aux.setter
     def aux(self, val):

--- a/do_mpc/model.py
+++ b/do_mpc/model.py
@@ -100,7 +100,7 @@ class IteratedVariables:
             mpc.x0['temperature']    # all elements of variable
             mpc.x0['temperature', 0:2]    # 0th and 1st element
 
-        Usefull CasADi symbolic structure methods:
+        Useful CasADi symbolic structure methods:
 
         * ``.shape``
 
@@ -138,7 +138,7 @@ class IteratedVariables:
             mpc.u0['heating']    # all elements of variable
             mpc.u0['heating', 0:2]    # 0th and 1st element
 
-        Usefull CasADi symbolic structure methods:
+        Useful CasADi symbolic structure methods:
 
         * ``.shape``
 
@@ -176,7 +176,7 @@ class IteratedVariables:
             mpc.z0['temperature']    # all elements of variable
             mpc.z0['temperature', 0:2]    # 0th and 1st element
 
-        Usefull CasADi symbolic structure methods:
+        Useful CasADi symbolic structure methods:
 
         * ``.shape``
 
@@ -403,7 +403,7 @@ class Model:
                 model.x['temperature']    # all elements of variable
                 model.x['temperature', 0:2]    # 0th and 1st element
 
-            Usefull CasADi symbolic structure methods:
+            Useful CasADi symbolic structure methods:
 
             * ``.shape``
 
@@ -412,13 +412,13 @@ class Model:
             * ``.labels()``
 
 
-            :raises assertion: Cannot set model variables direcly. Use set_variable instead.
+            :raises assertion: Cannot set model variables directly Use set_variable instead.
         """
         return self._getvar('_x')
 
     @x.setter
     def x(self, val):
-        raise Exception('Cannot set model variables direcly. Use set_variable instead.')
+        raise Exception('Cannot set model variables directly Use set_variable instead.')
 
     @property
     def u(self):
@@ -441,7 +441,7 @@ class Model:
                 model.u['heating']    # all elements of variable
                 model.u['heating', 0:2]    # 0th and 1st element
 
-            Usefull CasADi symbolic structure methods:
+            Useful CasADi symbolic structure methods:
 
             * ``.shape``
 
@@ -449,13 +449,13 @@ class Model:
 
             * ``.labels()``
 
-            :raises assertion: Cannot set model variables direcly. Use set_variable instead.
+            :raises assertion: Cannot set model variables directly Use set_variable instead.
         """
         return self._getvar('_u')
 
     @u.setter
     def u(self, val):
-        raise Exception('Cannot set model variables direcly. Use set_variable instead.')
+        raise Exception('Cannot set model variables directly Use set_variable instead.')
 
     @property
     def z(self):
@@ -478,7 +478,7 @@ class Model:
             model.z['temperature']    # all elements of variable
             model.z['temperature', 0:2]    # 0th and 1st element
 
-        Usefull CasADi symbolic structure methods:
+        Useful CasADi symbolic structure methods:
 
         * ``.shape``
 
@@ -487,13 +487,13 @@ class Model:
         * ``.labels()``
 
 
-        :raises assertion: Cannot set model variables direcly. Use set_variable instead.
+        :raises assertion: Cannot set model variables directly Use set_variable instead.
         """
         return self._getvar('_z')
 
     @z.setter
     def z(self, val):
-        raise Exception('Cannot set model variables direcly. Use set_variable instead.')
+        raise Exception('Cannot set model variables directly Use set_variable instead.')
 
     @property
     def p(self):
@@ -516,7 +516,7 @@ class Model:
             model.p['temperature']    # all elements of variable
             model.p['temperature', 0:2]    # 0th and 1st element
 
-        Usefull CasADi symbolic structure methods:
+        Useful CasADi symbolic structure methods:
 
         * ``.shape``
 
@@ -525,13 +525,13 @@ class Model:
         * ``.labels()``
 
 
-        :raises assertion: Cannot set model variables direcly. Use set_variable instead.
+        :raises assertion: Cannot set model variables directly Use set_variable instead.
         """
         return self._getvar('_p')
 
     @p.setter
     def p(self, val):
-        raise Exception('Cannot set model variables direcly. Use set_variable instead.')
+        raise Exception('Cannot set model variables directly Use set_variable instead.')
 
     @property
     def tvp(self):
@@ -554,7 +554,7 @@ class Model:
                 model.tvp['temperature']    # all elements of variable
                 model.tvp['temperature', 0:2]    # 0th and 1st element
 
-            Usefull CasADi symbolic structure methods:
+            Useful CasADi symbolic structure methods:
 
             * ``.shape``
 
@@ -562,13 +562,13 @@ class Model:
 
             * ``.labels()``
 
-            :raises assertion: Cannot set model variables direcly. Use set_variable instead.
+            :raises assertion: Cannot set model variables directly Use set_variable instead.
         """
         return self._getvar('_tvp')
 
     @tvp.setter
     def tvp(self, val):
-        raise Exception('Cannot set model variables direcly. Use set_variable instead.')
+        raise Exception('Cannot set model variables directly Use set_variable instead.')
 
     @property
     def y(self):
@@ -591,7 +591,7 @@ class Model:
                 model.y['temperature', 0] # 0th element of variable
                 model.y['temperature']    # all elements of variable
 
-            Usefull CasADi symbolic structure methods:
+            Useful CasADi symbolic structure methods:
 
             * ``.shape``
 
@@ -599,13 +599,13 @@ class Model:
 
             * ``.labels()``
 
-            :raises assertion: Cannot set model variables direcly. Use set_meas instead.
+            :raises assertion: Cannot set model variables directly Use set_meas instead.
         """
         return self._getvar('_y')
 
     @y.setter
     def y(self, val):
-        raise Exception('Cannot set model variables direcly. Use set_variable instead.')
+        raise Exception('Cannot set model variables directly Use set_variable instead.')
 
     @property
     def aux(self):
@@ -629,7 +629,7 @@ class Model:
                 model.aux['dtemp', 0] # 0th element of variable
                 model.aux['dtemp']    # all elements of variable
 
-            Usefull CasADi symbolic structure methods:
+            Useful CasADi symbolic structure methods:
 
             * ``.shape``
 
@@ -637,13 +637,13 @@ class Model:
 
             * ``.labels()``
 
-            :raises assertion: Cannot set aux direcly. Use set_expression instead.
+            :raises assertion: Cannot set aux directly Use set_expression instead.
         """
         return self._getvar('_aux')
 
     @aux.setter
     def aux(self, val):
-        raise Exception('Cannot set model variables direcly. Use set_variable instead.')
+        raise Exception('Cannot set model variables directly Use set_variable instead.')
 
     @property
     def w(self):
@@ -658,7 +658,7 @@ class Model:
                 The process noise is used for the :py:class:`do_mpc.estimator.MHE` and
                 can be used to simulate a disturbed system in the :py:class:`do_mpc.simulator.Simulator`.
 
-            Usefull CasADi symbolic structure methods:
+            Useful CasADi symbolic structure methods:
 
             * ``.shape``
 
@@ -666,7 +666,7 @@ class Model:
 
             * ``.labels()``
 
-            :raises assertion: Cannot set w direcly.
+            :raises assertion: Cannot set w directly
         """
         return self._getvar('_w')
 
@@ -688,7 +688,7 @@ class Model:
                 The measurement noise is used for the :py:class:`do_mpc.estimator.MHE` and
                 can be used to simulate a disturbed system in the :py:class:`do_mpc.simulator.Simulator`.
 
-            Usefull CasADi symbolic structure methods:
+            Useful CasADi symbolic structure methods:
 
             * ``.shape``
 
@@ -696,7 +696,7 @@ class Model:
 
             * ``.labels()``
 
-            :raises assertion: Cannot set v direcly.
+            :raises assertion: Cannot set v directly
         """
         return self._getvar('_v')
 


### PR DESCRIPTION
Earlier I created an issue re. the accessibility of the model.aux property. Here is my suggested fix. I base this on the structure of all other property getters and the data types of ._aux vs ._aux_expression. The former matches the required data type for the _convert2struct call in _getvar. 

See l.642 for my change.

I've also picked up on some typos in the documentation and fixed those in a second commit.