### PR TITLE
v4.4.0

### DIFF
--- a/do_mpc/controller.py
+++ b/do_mpc/controller.py
@@ -1076,6 +1076,43 @@ class MPC(do_mpc.optimizer.Optimizer, do_mpc.model.IteratedVariables):
         return u0.full()
 
 
+    def _update_bounds(self):
+        """Private method to update the bounds of the optimization variables based on the current values defined with :py:attr:`scaling`.
+        """
+        if self.cons_check_colloc_points:   # Constraints for all collocation points.
+            # Dont bound the initial state
+            self.lb_opt_x['_x', 1:self.n_horizon] = self._x_lb.cat/self._x_scaling
+            self.ub_opt_x['_x', 1:self.n_horizon] = self._x_ub.cat/self._x_scaling
+
+            # Bounds for the algebraic variables:
+            self.lb_opt_x['_z'] = self._z_lb.cat/self._z_scaling
+            self.ub_opt_x['_z'] = self._z_ub.cat/self._z_scaling
+
+            # Terminal bounds
+            self.lb_opt_x['_x', self.n_horizon, :, -1] = self._x_terminal_lb.cat/self._x_scaling
+            self.ub_opt_x['_x', self.n_horizon, :, -1] = self._x_terminal_ub.cat/self._x_scaling
+        else:   # Constraints only at the beginning of the finite Element
+            # Dont bound the initial state
+            self.lb_opt_x['_x', 1:self.n_horizon, :, -1] = self._x_lb.cat/self._x_scaling
+            self.ub_opt_x['_x', 1:self.n_horizon, :, -1] = self._x_ub.cat/self._x_scaling
+
+            # Bounds for the algebraic variables:
+            self.lb_opt_x['_z', :, :, 0] = self._z_lb.cat/self._z_scaling
+            self.ub_opt_x['_z', :, : ,0] = self._z_ub.cat/self._z_scaling
+
+            # Terminal bounds
+            self.lb_opt_x['_x', self.n_horizon, :, -1] = self._x_terminal_lb.cat/self._x_scaling
+            self.ub_opt_x['_x', self.n_horizon, :, -1] = self._x_terminal_ub.cat/self._x_scaling
+
+        # Bounds for the inputs along the horizon
+        self.lb_opt_x['_u'] = self._u_lb.cat/self._u_scaling
+        self.ub_opt_x['_u'] = self._u_ub.cat/self._u_scaling
+
+        # Bounds for the slack variables:
+        self.lb_opt_x['_eps'] = self._eps_lb.cat
+        self.ub_opt_x['_eps'] = self._eps_ub.cat
+
+
     def _prepare_nlp(self):
         """Internal method. See detailed documentation with optimizer.prepare_nlp
         """
@@ -1147,8 +1184,8 @@ class MPC(do_mpc.optimizer.Optimizer, do_mpc.model.IteratedVariables):
 
         self.n_opt_aux = opt_aux.shape[0]
 
-        self.lb_opt_x = opt_x(-np.inf)
-        self.ub_opt_x = opt_x(np.inf)
+        self._lb_opt_x = opt_x(-np.inf)
+        self._ub_opt_x = opt_x(np.inf)
 
         # Initialize objective function and constraints
         obj = DM(0)
@@ -1244,40 +1281,8 @@ class MPC(do_mpc.optimizer.Optimizer, do_mpc.model.IteratedVariables):
                     opt_aux['_aux', k, s_] = self.model._aux_expression_fun(
                         opt_x_unscaled['_x', k, s, -1], opt_x_unscaled['_u', k, s_u], opt_x_unscaled['_z', k, s, -1], opt_p['_tvp', k], opt_p['_p', current_scenario])
 
-
-
-        if self.cons_check_colloc_points:   # Constraints for all collocation points.
-            # Dont bound the initial state
-            self.lb_opt_x['_x', 1:self.n_horizon] = self._x_lb.cat/self._x_scaling
-            self.ub_opt_x['_x', 1:self.n_horizon] = self._x_ub.cat/self._x_scaling
-
-            # Bounds for the algebraic variables:
-            self.lb_opt_x['_z'] = self._z_lb.cat/self._z_scaling
-            self.ub_opt_x['_z'] = self._z_ub.cat/self._z_scaling
-
-            # Terminal bounds
-            self.lb_opt_x['_x', self.n_horizon, :, -1] = self._x_terminal_lb.cat/self._x_scaling
-            self.ub_opt_x['_x', self.n_horizon, :, -1] = self._x_terminal_ub.cat/self._x_scaling
-        else:   # Constraints only at the beginning of the finite Element
-            # Dont bound the initial state
-            self.lb_opt_x['_x', 1:self.n_horizon, :, -1] = self._x_lb.cat/self._x_scaling
-            self.ub_opt_x['_x', 1:self.n_horizon, :, -1] = self._x_ub.cat/self._x_scaling
-
-            # Bounds for the algebraic variables:
-            self.lb_opt_x['_z', :, :, 0] = self._z_lb.cat/self._z_scaling
-            self.ub_opt_x['_z', :, : ,0] = self._z_ub.cat/self._z_scaling
-
-            # Terminal bounds
-            self.lb_opt_x['_x', self.n_horizon, :, -1] = self._x_terminal_lb.cat/self._x_scaling
-            self.ub_opt_x['_x', self.n_horizon, :, -1] = self._x_terminal_ub.cat/self._x_scaling
-
-        # Bounds for the inputs along the horizon
-        self.lb_opt_x['_u'] = self._u_lb.cat/self._u_scaling
-        self.ub_opt_x['_u'] = self._u_ub.cat/self._u_scaling
-
-        # Bounds for the slack variables:
-        self.lb_opt_x['_eps'] = self._eps_lb.cat
-        self.ub_opt_x['_eps'] = self._eps_ub.cat
+        # Set bounds for all optimization variables
+        self._update_bounds()
 
 
         # Write all created elements to self:

--- a/do_mpc/controller.py
+++ b/do_mpc/controller.py
@@ -1081,32 +1081,32 @@ class MPC(do_mpc.optimizer.Optimizer, do_mpc.model.IteratedVariables):
         """
         if self.cons_check_colloc_points:   # Constraints for all collocation points.
             # Dont bound the initial state
-            self.lb_opt_x['_x', 1:self.n_horizon] = self._x_lb.cat/self._x_scaling
-            self.ub_opt_x['_x', 1:self.n_horizon] = self._x_ub.cat/self._x_scaling
+            self.lb_opt_x['_x', 1:self.n_horizon] = self._x_lb.cat
+            self.ub_opt_x['_x', 1:self.n_horizon] = self._x_ub.cat
 
             # Bounds for the algebraic variables:
-            self.lb_opt_x['_z'] = self._z_lb.cat/self._z_scaling
-            self.ub_opt_x['_z'] = self._z_ub.cat/self._z_scaling
+            self.lb_opt_x['_z'] = self._z_lb.cat
+            self.ub_opt_x['_z'] = self._z_ub.cat
 
             # Terminal bounds
-            self.lb_opt_x['_x', self.n_horizon, :, -1] = self._x_terminal_lb.cat/self._x_scaling
-            self.ub_opt_x['_x', self.n_horizon, :, -1] = self._x_terminal_ub.cat/self._x_scaling
+            self.lb_opt_x['_x', self.n_horizon, :, -1] = self._x_terminal_lb.cat
+            self.ub_opt_x['_x', self.n_horizon, :, -1] = self._x_terminal_ub.cat
         else:   # Constraints only at the beginning of the finite Element
             # Dont bound the initial state
-            self.lb_opt_x['_x', 1:self.n_horizon, :, -1] = self._x_lb.cat/self._x_scaling
-            self.ub_opt_x['_x', 1:self.n_horizon, :, -1] = self._x_ub.cat/self._x_scaling
+            self.lb_opt_x['_x', 1:self.n_horizon, :, -1] = self._x_lb.cat
+            self.ub_opt_x['_x', 1:self.n_horizon, :, -1] = self._x_ub.cat
 
             # Bounds for the algebraic variables:
-            self.lb_opt_x['_z', :, :, 0] = self._z_lb.cat/self._z_scaling
-            self.ub_opt_x['_z', :, : ,0] = self._z_ub.cat/self._z_scaling
+            self.lb_opt_x['_z', :, :, 0] = self._z_lb.cat
+            self.ub_opt_x['_z', :, : ,0] = self._z_ub.cat
 
             # Terminal bounds
-            self.lb_opt_x['_x', self.n_horizon, :, -1] = self._x_terminal_lb.cat/self._x_scaling
-            self.ub_opt_x['_x', self.n_horizon, :, -1] = self._x_terminal_ub.cat/self._x_scaling
+            self.lb_opt_x['_x', self.n_horizon, :, -1] = self._x_terminal_lb.cat
+            self.ub_opt_x['_x', self.n_horizon, :, -1] = self._x_terminal_ub.cat
 
         # Bounds for the inputs along the horizon
-        self.lb_opt_x['_u'] = self._u_lb.cat/self._u_scaling
-        self.ub_opt_x['_u'] = self._u_ub.cat/self._u_scaling
+        self.lb_opt_x['_u'] = self._u_lb.cat
+        self.ub_opt_x['_u'] = self._u_ub.cat
 
         # Bounds for the slack variables:
         self.lb_opt_x['_eps'] = self._eps_lb.cat

--- a/do_mpc/data.py
+++ b/do_mpc/data.py
@@ -307,7 +307,8 @@ class MPCData(Data):
                 f_ind = self.opt_x.f[(ind[0], slice(None), lambda v: horzcat(*v),slice(None), -1)+ind[1:]]
                 f_ind = np.array([f_ind_k.full() for f_ind_k in f_ind], dtype='int32')
                 # sort pred such that each column belongs to one scenario
-                f_ind = f_ind[range(f_ind.shape[0]),:,structure_scenario.T].T
+                # - By indexing structure_scenario until f_ind.shape[0] we cover the case of _x and _z at the same time
+                f_ind = f_ind[range(f_ind.shape[0]),:,structure_scenario[:f_ind.shape[0],:].T].T
                 # Store f_ind:
                 self.prediction_queries['ind'].append(ind)
                 self.prediction_queries['f_ind'].append(f_ind)

--- a/do_mpc/estimator.py
+++ b/do_mpc/estimator.py
@@ -1149,35 +1149,40 @@ class MHE(do_mpc.optimizer.Optimizer, Estimator):
 
     def _update_bounds(self):
         """Private method to update the bounds of the optimization variables based on the current values defined with :py:attr:`scaling`.
+
+        .. note::
+
+            Bounds are automatically scaled as they invoke the :py:attr:lb_opt_x` and :py:attr:`ub_opt_x` methods. Scaling is done automatically in these methods.
         """
+        
         if self.cons_check_colloc_points:   # Constraints for all collocation points.
             # Bounds for the states on all discretize values along the horizon
-            self.lb_opt_x['_x'] = self._x_lb.cat/self._x_scaling
-            self.ub_opt_x['_x'] = self._x_ub.cat/self._x_scaling
+            self.lb_opt_x['_x'] = self._x_lb.cat
+            self.ub_opt_x['_x'] = self._x_ub.cat
 
             # Bounds for the algebraic states along the horizon
-            self.lb_opt_x['_z'] = self._z_lb.cat/self._z_scaling
-            self.ub_opt_x['_z'] = self._z_ub.cat/self._z_scaling
+            self.lb_opt_x['_z'] = self._z_lb.cat
+            self.ub_opt_x['_z'] = self._z_ub.cat
         else:   # Constraints only at the beginning of the finite Element
             # Bounds for the states on all discretize values along the horizon
-            self.lb_opt_x['_x', 1:self.n_horizon, -1] = self._x_lb.cat/self._x_scaling
-            self.ub_opt_x['_x', 1:self.n_horizon, -1] = self._x_ub.cat/self._x_scaling
+            self.lb_opt_x['_x', 1:self.n_horizon, -1] = self._x_lb.cat
+            self.ub_opt_x['_x', 1:self.n_horizon, -1] = self._x_ub.cat
 
             # Bounds for the algebraic states along the horizon
-            self.lb_opt_x['_z', :, 0] = self._z_lb.cat/self._z_scaling
-            self.ub_opt_x['_z', :, 0] = self._z_ub.cat/self._z_scaling
+            self.lb_opt_x['_z', :, 0] = self._z_lb.cat
+            self.ub_opt_x['_z', :, 0] = self._z_ub.cat
 
         # Bounds for the inputs along the horizon
-        self.lb_opt_x['_u'] = self._u_lb.cat/self._u_scaling
-        self.ub_opt_x['_u'] = self._u_ub.cat/self._u_scaling
+        self.lb_opt_x['_u'] = self._u_lb.cat
+        self.ub_opt_x['_u'] = self._u_ub.cat
 
         # Bounds for the slack variables along the horizon:
         self.lb_opt_x['_eps'] = self._eps_lb.cat
         self.ub_opt_x['_eps'] = self._eps_ub.cat
 
         # Bounds for the inputs along the horizon
-        self.lb_opt_x['_p_est'] = self._p_est_lb.cat/self._p_est_scaling
-        self.ub_opt_x['_p_est'] = self._p_est_ub.cat/self._p_est_scaling
+        self.lb_opt_x['_p_est'] = self._p_est_lb.cat
+        self.ub_opt_x['_p_est'] = self._p_est_ub.cat
 
     def _prepare_nlp(self):
         """Internal method. See detailed documentation in optimizer.prepare_nlp
@@ -1248,8 +1253,8 @@ class MHE(do_mpc.optimizer.Optimizer, Estimator):
 
         self.n_opt_aux = opt_aux.shape[0]
 
-        self.lb_opt_x = opt_x(-np.inf)
-        self.ub_opt_x = opt_x(np.inf)
+        self._lb_opt_x = opt_x(-np.inf)
+        self._ub_opt_x = opt_x(np.inf)
 
         # Initialize objective function and constraints
         obj = DM(0)

--- a/do_mpc/model.py
+++ b/do_mpc/model.py
@@ -25,6 +25,7 @@ from casadi import *
 from casadi.tools import *
 import pdb
 import warnings
+from do_mpc.tools.casstructure import _SymVar, _struct_MX, _struct_SX
 
 
 class IteratedVariables:
@@ -215,22 +216,6 @@ class IteratedVariables:
             raise Exception('Passing object of type {} to set the current time. Must be of type {}'.format(type(val), types))
 
 
-class _SymVar:
-    def __init__(self, symvar_type):
-        assert symvar_type in ['SX', 'MX'], 'symvar_type must be either SX or MX, you have: {}'.format(symvar_type)
-
-        if symvar_type == 'MX':
-            self.sym = MX.sym
-            self.struct = struct_MX
-            self.sym_struct = struct_symMX
-            self.dtype = MX
-        if symvar_type == 'SX':
-            self.sym = SX.sym
-            self.struct = struct_SX
-            self.sym_struct = struct_symSX
-            self.dtype = SX
-
-
 class Model:
     """The **do-mpc** model class. This class holds the full model description and is at the core of
     :py:class:`do_mpc.simulator.Simulator`, :py:class:`do_mpc.controller.MPC` and :py:class:`do_mpc.estimator.Estimator`.
@@ -332,6 +317,41 @@ class Model:
         self.flags = {
             'setup': False
         }
+
+    def __getstate__(self):
+        """
+        Returns the state of the :py:class:`Model` for pickling.
+
+        .. warning::
+
+            The :py:class:`Model` class supports pickling only if:
+
+            1. The model is configured with ``SX`` variables.
+
+            2. The model is setup with :py:func:`setup`.
+        """
+        # Raise exception if model is using MX symvars
+        if self.symvar_type == 'MX':
+            raise Exception('Pickling of models using MX symvars is not supported.')
+        # Raise exception if model is not setup
+        if not self.flags['setup']:
+            raise Exception('Pickling of unsetup models is not supported.')
+
+        state = self.__dict__.copy()
+        return state
+
+    def __setstate__(self, state):
+        """
+        Sets the state of the :py:class:`Model` for unpickling. Please see :py:func:`__getstate__` for details and restrictions on pickling.
+        """
+        self.__dict__.update(state)
+
+        # Update expressions with new symbolic variables created when unpickling:
+        self._rhs = self._rhs(self._rhs_fun(self._x, self._u, self._z, self._tvp, self._p, self._w))
+        self._alg = self._alg(self._alg_fun(self._x, self._u, self._z, self._tvp, self._p, self._w))
+        self._aux_expression = self._aux_expression(self._aux_expression_fun(self._x, self._u, self._z, self._tvp, self._p))
+        self._y_expression = self._y_expression(self._meas_fun(self._x, self._u, self._z, self._tvp, self._p, self._v))
+
 
     def __getitem__(self, ind):
         """The :py:class:`Model` class supports the ``__getitem__`` method,
@@ -1064,7 +1084,12 @@ class Model:
             for var, name in zip(var_dict['var'], var_dict['name']):
                 subs = substitute(subs, var, sym_struct[name])
 
-        return expr(subs)
+        if self.symvar_type == 'MX':
+            expr = expr(subs)
+        else:
+            expr.master = subs
+        
+        return expr
 
     def _substitute_exported_vars(self, var_dict_list, sym_struct_list):
         """Helper function for :py:func:`setup`. Not part of the public API.

--- a/do_mpc/tools/casstructure.py
+++ b/do_mpc/tools/casstructure.py
@@ -1,0 +1,28 @@
+from casadi import *
+from casadi.tools import *
+
+class _struct_SX(struct_SX):
+    """Updated structure class for CasADi structures (SX). This class fixes a bug that prevents unpickeling of the structure."""
+    def __init__(self, *args, **kwargs):
+        kwargs.pop('order', None)
+        super().__init__(*args, **kwargs) 
+
+class _struct_MX(struct_MX):
+    def __init__(self, *args, **kwargs):
+        kwargs.pop('order', None)
+        super().__init__(*args, **kwargs) 
+
+class _SymVar:
+    def __init__(self, symvar_type):
+        assert symvar_type in ['SX', 'MX'], 'symvar_type must be either SX or MX, you have: {}'.format(symvar_type)
+
+        if symvar_type == 'MX':
+            self.sym = MX.sym
+            self.struct = _struct_MX
+            self.sym_struct = struct_symMX
+            self.dtype = MX
+        if symvar_type == 'SX':
+            self.sym = SX.sym
+            self.struct = _struct_SX
+            self.sym_struct = struct_symSX
+            self.dtype = SX

--- a/do_mpc/tools/timer.py
+++ b/do_mpc/tools/timer.py
@@ -44,15 +44,18 @@ class Timer:
         msg = 'Average runtime {avg}+-{var}{unit}. Fastest run {min}{unit}, slowest run {max}{unit}.'
         print(msg.format(avg=t_mean, var=t_var, unit=self.unit, min=t_min, max=t_max))
 
-    def hist(self, ax=None, *args, **kwargs):
+    def hist(self, *args, **kwargs):
         t_arr = np.round(np.array(self.t_list)*self.factor)
         t_mean = np.mean(t_arr)
-        if ax == None:
-            fig, ax = plt.subplots()
 
+        fig, ax = plt.subplots()
         ax.axvline(t_mean, color='black')
         ax.hist(t_arr, *args, **kwargs)
         ax.set_xlabel('time in {}'.format(self.unit))
         ax.set_ylabel('number of instances')
 
         plt.show()
+
+        return fig, ax
+
+        

--- a/testing/test_CSTR.py
+++ b/testing/test_CSTR.py
@@ -27,6 +27,7 @@ from casadi.tools import *
 import pdb
 import sys
 import unittest
+import pickle
 
 from importlib import reload
 import copy
@@ -59,18 +60,31 @@ class TestCSTR(unittest.TestCase):
 
     def test_SX(self):
         print('Testing SX implementation')
-        self.CSTR('SX')
+        model = self.template_model.template_model('SX')
+        self.CSTR(model)
 
     def test_MX(self):
         print('Testing MX implementation')
-        self.CSTR('MX')
+        model = self.template_model.template_model('MX')
+        self.CSTR(model)
 
-    def CSTR(self, symvar_type):
+    def test_pickle_unpickle(self):
+        print('Testing SX implementation with pickle / unpickle')
+        # Test if pickling / unpickling works for the SX model:
+        model = self.template_model.template_model('SX')
+        with open('model.pkl', 'wb') as f:
+            pickle.dump(model, f)
+
+        # Load the casadi structure
+        with open('model.pkl', 'rb') as f:
+            model_unpickled = pickle.load(f)
+        self.CSTR(model_unpickled)
+
+    def CSTR(self, model):
         """
         Get configured do-mpc modules:
         """
 
-        model = self.template_model.template_model(symvar_type)
         mpc = self.template_mpc.template_mpc(model)
         simulator = self.template_simulator.template_simulator(model)
         estimator = do_mpc.estimator.StateFeedback(model)

--- a/testing/test_oscillating_masses_discrete_dae.py
+++ b/testing/test_oscillating_masses_discrete_dae.py
@@ -27,6 +27,7 @@ from casadi.tools import *
 import pdb
 import sys
 import unittest
+import pickle
 
 from importlib import reload
 import copy
@@ -57,18 +58,30 @@ class TestOscillatingMassesDiscrete(unittest.TestCase):
 
     def test_SX(self):
         print('Testing SX implementation')
-        self.oscillating_masses_discrete('SX')
+        model = self.template_model.template_model('SX')
+        self.oscillating_masses_discrete(model)
 
     def test_MX(self):
         print('Testing MX implementation')
-        self.oscillating_masses_discrete('MX')
+        model = self.template_model.template_model('MX')
+        self.oscillating_masses_discrete(model)
 
-    def oscillating_masses_discrete(self, symvar_type):
+    def test_pickle_unpickle(self):
+        print('Testing pickle and unpickle')
+        model = self.template_model.template_model('SX')
+        with open('model.pkl', 'wb') as f:
+            pickle.dump(model, f)
+
+        # Load the casadi structure
+        with open('model.pkl', 'rb') as f:
+            model_unpickled = pickle.load(f)
+        self.oscillating_masses_discrete(model_unpickled)
+
+        
+    def oscillating_masses_discrete(self, model):
         """
         Get configured do-mpc modules:
         """
-
-        model = self.template_model.template_model(symvar_type)
         mpc = self.template_mpc.template_mpc(model)
         simulator = self.template_simulator.template_simulator(model)
         estimator = do_mpc.estimator.StateFeedback(model)

--- a/testing/test_rotating_oscillating_masses_mhe_mpc.py
+++ b/testing/test_rotating_oscillating_masses_mhe_mpc.py
@@ -27,6 +27,7 @@ from casadi.tools import *
 import pdb
 import sys
 import unittest
+import pickle
 
 from importlib import reload
 import copy
@@ -58,17 +59,28 @@ class TestRotatingMasses(unittest.TestCase):
         sys.path = default_path
 
     def test_SX(self):
-        self.RotatingMasses('SX')
+        model = self.template_model.template_model('SX')
+        self.RotatingMasses(model)
 
     def test_MX(self):
-        self.RotatingMasses('MX')
+        model = self.template_model.template_model('MX')
+        self.RotatingMasses(model)
 
-    def RotatingMasses(self, symvar_type):
+    def test_pickle_unpickle(self):
+        model = self.template_model.template_model('SX')
+        with open('model.pkl', 'wb') as f:
+            pickle.dump(model, f)
+
+        # Load the casadi structure
+        with open('model.pkl', 'rb') as f:
+            model_unpickled = pickle.load(f)
+        self.RotatingMasses(model_unpickled)
+
+    def RotatingMasses(self, model):
         """
         Get configured do-mpc modules:
         """
 
-        model = self.template_model.template_model(symvar_type)
         mpc = self.template_mpc.template_mpc(model)
         simulator = self.template_simulator.template_simulator(model)
         mhe = self.template_mhe.template_mhe(model)


### PR DESCRIPTION
# Major changes
- MHE/MPC bounds on optimiziation variables can now be changed after calling ``mhe.setup()`` and ``mpc.setup()`` respectively (fixes #289). The simplest way to set bounds is the ``mhe.bounds`` and ``mpc.bounds`` property ([docs](https://www.do-mpc.com/en/latest/api/do_mpc.controller.MPC.bounds.html))
- More granular control over the bounds is now possible, e.g. choosing different values for each time-step of the horizon or for different collocation points (if that makes sense). For this purpose two now properties ``lb_opt_x`` and ``ub_opt_x`` are now documented and accessible to the user. These properties are indexed similarly to the property [opt_x](https://www.do-mpc.com/en/latest/api/do_mpc.controller.MPC.opt_x.html). Importantly, setting new values on these structure automatically considers the scaling factors.
- The do-mpc model can now be pickled. Pickling is restricted, however and requires (error messages are thrown otherwise):
    - the model class must be setup
    - the model must use ``SX`` symbolic variables
- Enhanced warmstarting: The solver is now supplied with a guess for the dual variables

# Minor changes 
- Bug fix: [MPCData.prediction](https://www.do-mpc.com/en/latest/api/do_mpc.data.MPCData.prediction.html) was previously unable to query algebraic states ``_z``.
- Fixed #283: Algebraic states can now be plotted with the graphics package