### PR TITLE
Fixed assertion error output string in simulator.set_initial_guess()

### DIFF
--- a/do_mpc/simulator.py
+++ b/do_mpc/simulator.py
@@ -384,7 +384,7 @@ class Simulator(do_mpc.model.IteratedVariables):
             If no initial values for :py:attr:`z0` were supplied during setup, they default to zero.
 
         """
-        assert self.flags['setup'] == True, 'MPC was not setup yet. Please call MPC.setup().'
+        assert self.flags['setup'] == True, 'Simulator was not setup yet. Please call Simulator.setup().'
 
         self.sim_z_num['_z'] = self._z0.cat
 


### PR DESCRIPTION
The assertion error in `simulator.setup()` told the user the following incorrect statement:
`MPC was not setup yet. Please call MPC.setup().`

I fixed it to:
`Simulator was not setup yet. Please call Simulator.setup().`