### PR TITLE
Make dependencies optional

### DIFF
--- a/do_mpc/controller/_lqr.py
+++ b/do_mpc/controller/_lqr.py
@@ -26,9 +26,15 @@ import numpy as np
 import warnings
 import pdb
 import do_mpc.data
-from scipy.linalg import solve_discrete_are
 from ..model import LinearModel, IteratedVariables
 from ._controllersettings import LQRSettings
+
+
+try:
+    from scipy.linalg import solve_discrete_are
+    SCIPY_INSTALLED = True
+except ImportError:
+    SCIPY_INSTALLED = False
 
 class LQR(IteratedVariables):
     """Linear Quadratic Regulator.
@@ -99,6 +105,9 @@ class LQR(IteratedVariables):
         model : Linear model
     """
     def __init__(self,model:LinearModel):
+        if not SCIPY_INSTALLED:
+            raise Exception("This class requires the package 'scipy' to be installed. Please install it.")
+        
         self.model = model
         IteratedVariables.__init__(self)
         

--- a/do_mpc/differentiator/_nlpdifferentiator.py
+++ b/do_mpc/differentiator/_nlpdifferentiator.py
@@ -21,7 +21,6 @@
 #   along with do-mpc.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-import scipy.linalg as sp_linalg
 import scipy.sparse as sp_sparse
 import casadi as ca
 import casadi.tools as castools 

--- a/do_mpc/differentiator/_nlpdifferentiator.py
+++ b/do_mpc/differentiator/_nlpdifferentiator.py
@@ -21,7 +21,6 @@
 #   along with do-mpc.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-import scipy.sparse as sp_sparse
 import casadi as ca
 import casadi.tools as castools 
 from dataclasses import dataclass
@@ -32,6 +31,13 @@ from do_mpc.optimizer import Optimizer
 from .helper import NLPDifferentiatorSettings, NLPDifferentiatorStatus
 
 import logging
+
+
+try:
+    import scipy.sparse as sp_sparse
+    SCIPY_INSTALLED = True
+except ImportError:
+    SCIPY_INSTALLED = False
 
 __all__ = ['NLPDifferentiator', 'DoMPCDifferentiator']
 
@@ -112,6 +118,8 @@ class NLPDifferentiator:
 
     """
     def __init__(self, nlp: Dict, nlp_bounds: Dict, **kwargs):
+        if not SCIPY_INSTALLED:
+            raise Exception("This class requires the package 'scipy' to be installed. Please install it.")
 
         nlp_mandatory_keys = ['f', 'x', 'p', 'g']
         nlp_bounds_mandatory_keys = ['lbx', 'ubx', 'lbg', 'ubg']

--- a/do_mpc/model/_linearmodel.py
+++ b/do_mpc/model/_linearmodel.py
@@ -24,10 +24,16 @@ from __future__ import annotations
 import numpy as np
 import pdb
 import warnings
-from scipy.signal import cont2discrete
 from . import Model
 from typing import Union
 import casadi.tools as castools
+
+
+try:
+    from scipy.signal import cont2discrete
+    SCIPY_INSTALLED = True
+except ImportError:
+    SCIPY_INSTALLED = False
 
 # Define what is included in the Sphinx documentation.
 __all__ = ['LinearModel']
@@ -263,6 +269,9 @@ class LinearModel(Model):
         Returns:
             Discretized linear model
         """
+        if not SCIPY_INSTALLED:
+            raise Exception("This method requires the package 'scipy' to be installed. Please install it.")
+        
         assert self.flags['setup'] == True, 'This method can be accessed only after the model is setup using LinearModel.setup().'
         assert self.model_type == 'continuous', 'Given model is already discrete.'
 

--- a/do_mpc/opcua/__init__.py
+++ b/do_mpc/opcua/__init__.py
@@ -6,7 +6,4 @@ from ._server import RTServer
 from ._client import RTClient
 from ._base import RTBase
 from ._helper import NamespaceEntry, Namespace, ServerOpts, ClientOpts
-try:
-    import asyncua.sync as opcua
-except ImportError:
-    raise ImportError("The asyncua library is not installed. Please install it and try again.")
+

--- a/do_mpc/opcua/_client.py
+++ b/do_mpc/opcua/_client.py
@@ -27,8 +27,9 @@ from ._helper import Namespace, ClientOpts
 
 try:
     import asyncua.sync as opcua
+    ASYNCUA_INSTALLED = True
 except ImportError:
-    raise ImportError("The asyncua library is not installed. Please install it and try again.")
+    ASYNCUA_INSTALLED = False
 
 class RTClient:
     '''
@@ -61,6 +62,9 @@ class RTClient:
     '''
 
     def __init__(self, opts:ClientOpts, namespace:Namespace)->None:
+        if not ASYNCUA_INSTALLED:
+            raise Exception("This class requires the package 'asyncua' to be installed. Please install it.")
+        
         # Information for connection to server
         self.server_address = opts.address
         self.port           = opts.port

--- a/do_mpc/opcua/_server.py
+++ b/do_mpc/opcua/_server.py
@@ -29,8 +29,9 @@ from ._client import RTClient
 
 try:
     import asyncua.sync as opcua
+    ASYNCUA_INSTALLED = True
 except ImportError:
-    raise ImportError("The asyncua library is not installed. Please install it and try again.")
+    ASYNCUA_INSTALLED = False
 
 
 
@@ -61,6 +62,8 @@ class RTServer:
     '''
 
     def __init__(self, opts:ServerOpts)->None:
+        if not ASYNCUA_INSTALLED:
+            raise Exception("This class requires the package 'asyncua' to be installed. Please install it.")
        
         # The basic OPCUA server definition contains a name, address and a port numer
         self.name    = opts.name

--- a/do_mpc/sampling/_datahandler.py
+++ b/do_mpc/sampling/_datahandler.py
@@ -5,7 +5,6 @@ import os
 import numpy as np
 import pathlib
 import pdb
-import scipy.io as sio
 import copy
 from do_mpc.tools import load_pickle, save_pickle
 import types
@@ -13,6 +12,12 @@ import logging
 from inspect import signature
 from typing import Union
 
+
+try:
+    import scipy.io as sio
+    SCIPY_INSTALLED = True
+except ImportError:
+    SCIPY_INSTALLED = False
 
 class DataHandler:
     """Post-processing data created from a sampling plan.
@@ -243,6 +248,9 @@ class DataHandler:
     def _load(self, sample_id):
         """ Private method: Load data generated from a sampling plan, either '.pkl' or '.mat'
         """
+        if not SCIPY_INSTALLED:
+            raise Exception("This method requires the package 'scipy' to be installed. Please install it.")
+        
         name = '{sample_name}_{id}'.format(sample_name=self.sample_name, id=sample_id)
 
         if self.save_format == 'pickle':

--- a/do_mpc/sampling/_sampler.py
+++ b/do_mpc/sampling/_sampler.py
@@ -5,10 +5,15 @@ import inspect
 import numpy as np
 import pathlib
 import pdb
-import scipy.io as sio
 import copy
 from do_mpc.tools import load_pickle, save_pickle, printProgressBar
 from typing import Union,Callable
+
+try:
+    import scipy.io as sio
+    SCIPY_INSTALLED = True
+except ImportError:
+    SCIPY_INSTALLED = False
 
 class Sampler:
     """Generate samples based on a sampling plan.
@@ -188,6 +193,9 @@ class Sampler:
         """Private method. Saves the result for a single sample in the defined format.
         Considers the ``overwrite`` parameter to check if existing results should be overwritten.
         """
+        if not SCIPY_INSTALLED:
+            raise Exception("This method requires the package 'scipy' to be installed. Please install it.")
+        
         if not os.path.isfile(self.data_dir + save_name) or self.overwrite:
             if self.save_format == 'pickle':
                 save_pickle(self.data_dir + save_name, result)

--- a/do_mpc/sampling/_samplingplanner.py
+++ b/do_mpc/sampling/_samplingplanner.py
@@ -4,7 +4,6 @@ import os
 import numpy as np
 import pathlib
 import pdb
-import scipy.io as sio
 import copy
 import itertools
 from do_mpc.tools import load_pickle, save_pickle

--- a/do_mpc/sysid/_onnxconversion.py
+++ b/do_mpc/sysid/_onnxconversion.py
@@ -1,19 +1,17 @@
 import casadi
-import onnx
-from onnx import numpy_helper
 import numpy as np
 import pdb
-import importlib
 from typing import List, Dict, Tuple, Union, Callable, Any, Optional
 
 
 # Import optional packages
 
-ONNX_INSTALLED = False
-
-if importlib.util.find_spec("onnx"):
+try:
     import onnx
+    from onnx import numpy_helper
     ONNX_INSTALLED = True
+except ImportError:
+    ONNX_INSTALLED = False
 
 class ONNXConversion:
     """ Transform `ONNX model <https://onnx.ai>`_. 
@@ -107,13 +105,13 @@ class ONNXConversion:
 
     """
     
-    def __init__(self, model: onnx.onnx_ml_pb2.ModelProto, model_name: Optional[str]=None):  
+    def __init__(self, model: "onnx.onnx_ml_pb2.ModelProto", model_name: Optional[str]=None):  
         if not ONNX_INSTALLED:
             raise Exception("The package 'onnx' is not installed. Please install it..")
 
         # In case of a keras model as input, convert it to an ONNX model
         
-        if isinstance(model,(onnx.onnx_ml_pb2.ModelProto)):
+        if isinstance(model,("onnx.onnx_ml_pb2.ModelProto")):
             self.onnx_model = model
             self.name = "casadi_model" if not isinstance(model_name, (str)) else model_name
         else:


### PR DESCRIPTION
I've found out that when `pip install`ing do-mpc in a clean environment, I cannot use it directly without installing also importlib, SciPy, Asyncua and ONNX, even though they are not direct dependencies of do-mpc. Minimal steps to reproduce the issue (I'm using Python 3.8 on macos):

- create a virtual environment `python3 -m venv env` and activate `source env/bin/activate`
- `pip install do-mpc`
- open python terminal: `python`
- in Python terminal, type `import do_mpc`

It will fail until those libraries are installed. This happens because there is a chain of imports from the main `__init__.py` to the subfolders, loading every single class of do_mpc. Installation of the ONNX package is already kinda checked [here](https://github.com/do-mpc/do-mpc/blob/7e9bbf71cdecad46d3aa2ca2acc881c501ace23f/do_mpc/sysid/_onnxconversion.py#L12) but then it's still imported at line 3 and it also requires `importlib` even though the same check can be performed with a `try..except`.

This PR proposes to keep these dependencies as not required and moves raising of the exceptions more or less in the exact places where they are needed.