### PR TITLE
Bugfix for Python>=3.11: inspect.getargspec was removed from python

### DIFF
--- a/do_mpc/sampling/_sampler.py
+++ b/do_mpc/sampling/_sampler.py
@@ -162,7 +162,7 @@ class Sampler:
             sample_function: Function to create each sample of the sampling plan.
         """
         assert isinstance(sample_function, (types.FunctionType, types.BuiltinFunctionType)), 'sample_function must be a function'
-        dset = set(inspect.getargspec(sample_function).args) - set(self.sampling_vars)
+        dset = set(inspect.getfullargspec(sample_function).args) - set(self.sampling_vars)
         assert len(dset) == 0, 'sample_function must only contain keyword arguments that appear as sample vars in the sampling_plan. You have the unknown arguments: {}'.format(dset)
 
         self.sample_function = sample_function


### PR DESCRIPTION
Explanation: [https://docs.python.org/3/whatsnew/3.11.html#removed](https://docs.python.org/3/whatsnew/3.11.html#removed)

Fix: Change inspect.getargspec() to inspect.getfullargspec