### PR TITLE
Bugfix: enable optimizer NLP complication feature for users

### DIFF
--- a/do_mpc/optimizer.py
+++ b/do_mpc/optimizer.py
@@ -24,6 +24,7 @@
 Shared tools for optimization-based estimation (MHE) and control (MPC).
 """
 import numpy as np
+import casadi
 import casadi.tools as castools
 import pdb
 import do_mpc
@@ -36,7 +37,7 @@ class Optimizer:
     This class establishes the jointly used attributes, methods and properties.
 
     Warnings:
-        The ``Optimizer`` base class can not be used independently. The methods and properties are 
+        The ``Optimizer`` base class can not be used independently. The methods and properties are
         inherited to :py:class:`do_mpc.estimator.MHE` and :py:class:`do_mpc.controller.MPC`.
     """
     def __init__(self):
@@ -220,7 +221,7 @@ class Optimizer:
         This is a more advanced method of setting bounds on optimization variables of the MPC/MHE problem.
         Users with less experience are advised to use :py:attr:`bounds` instead.
 
-        The attribute returns a nested structure that can be indexed using powerindexing. Please refer to :py:attr:`opt_x` for more details. 
+        The attribute returns a nested structure that can be indexed using powerindexing. Please refer to :py:attr:`opt_x` for more details.
 
         Note:
             The attribute automatically considers the scaling variables when setting the bounds. See :py:attr:`scaling` for more details.
@@ -228,16 +229,16 @@ class Optimizer:
         Note:
             Modifications must be done after calling :py:meth:`prepare_nlp` or :py:meth:`setup` respectively.
         """
-        return self._lb_opt_x[ind] 
+        return self._lb_opt_x[ind]
 
     @lb_opt_x.setter
     def lb_opt_x(self, ind, val):
         self._lb_opt_x[ind] = val
-        # Get canonical index 
+        # Get canonical index
         cind = self._lb_opt_x.f[ind]
         # Modify the newly set values by considering the scaling variables. This requires the canonical index.
         self._lb_opt_x.master[cind] = self._lb_opt_x.master[cind]/self.opt_x_scaling.master[cind]
-        
+
 
 
     @do_mpc.tools.IndexedProperty
@@ -246,7 +247,7 @@ class Optimizer:
         This is a more advanced method of setting bounds on optimization variables of the MPC/MHE problem.
         Users with less experience are advised to use :py:attr:`bounds` instead.
 
-        The attribute returns a nested structure that can be indexed using powerindexing. Please refer to :py:attr:`opt_x` for more details. 
+        The attribute returns a nested structure that can be indexed using powerindexing. Please refer to :py:attr:`opt_x` for more details.
 
         Note:
             The attribute automatically considers the scaling variables when setting the bounds. See :py:attr:`scaling` for more details.
@@ -480,12 +481,12 @@ class Optimizer:
 
         self.data.init_storage()
 
-    def set_nl_cons(self, 
-                    expr_name:str, 
-                    expr:Union[castools.SX,castools.MX], 
-                    ub:float=np.inf, 
-                    soft_constraint:bool=False, 
-                    penalty_term_cons:int=1, 
+    def set_nl_cons(self,
+                    expr_name:str,
+                    expr:Union[castools.SX,castools.MX],
+                    ub:float=np.inf,
+                    soft_constraint:bool=False,
+                    penalty_term_cons:int=1,
                     maximum_violation:float=np.inf)->Union[castools.SX,castools.MX]:
         """Introduce new constraint to the class. Further constraints are optional.
         Expressions must be formulated with respect to ``_x``, ``_u``, ``_z``, ``_tvp``, ``_p``.
@@ -681,13 +682,13 @@ class Optimizer:
         If an existing compilation with the name ``libname`` is found, it is used. **This can be dangerous, if the NLP has changed**
         (user tweaked the cost function, the model etc.).
 
-        Warnings: 
+        Warnings:
             This feature is experimental and currently only supported on Linux and MacOS.
 
         **What happens here?**
-        
+
         1. The NLP is written to a C-file (``cname``)
-        
+
         2. The C-File (``cname``) is compiled. The custom compiler uses:
 
         ::
@@ -698,7 +699,7 @@ class Optimizer:
 
         ::
 
-            self.S = nlpsol('solver_compiled', 'ipopt', f'{libname}', self.nlpsol_opts)      
+            self.S = casadi.nlpsol('solver_compiled', 'ipopt', f'{libname}', self.nlpsol_opts)
 
         Args:
             overwrite: If True, the existing compiled NLP will be overwritten.
@@ -725,7 +726,7 @@ class Optimizer:
             subprocess.Popen(compiler_command, shell=True).wait()
 
         # Overwrite solver object with loaded nlp:
-        self.S = nlpsol('solver_compiled', 'ipopt', libname, self.settings.nlpsol_opts)
+        self.S = casadi.nlpsol('solver_compiled', 'ipopt', libname, self.settings.nlpsol_opts)
         print('Using compiled NLP solver.')
 
     def solve(self)->None:
@@ -1051,7 +1052,7 @@ class Optimizer:
             Only AFTER calling :py:meth:`prepare_nlp` the previously mentionned attributes
             :py:attr:`nlp_obj`, :py:attr:`nlp_cons`, :py:attr:`nlp_cons_lb`, :py:attr:`nlp_cons_ub`
             become available.
-        
+
         Returns:
             None
         """

--- a/testing/test_batch_reactor_compiled.py
+++ b/testing/test_batch_reactor_compiled.py
@@ -1,0 +1,155 @@
+#
+#   This file is part of do-mpc
+#
+#   do-mpc: An environment for the easy, modular and efficient implementation of
+#        robust nonlinear model predictive control
+#
+#   Copyright (c) 2014-2019 Sergio Lucia, Alexandru Tatulea-Codrean
+#                        TU Dortmund. All rights reserved
+#
+#   do-mpc is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Lesser General Public License as
+#   published by the Free Software Foundation, either version 3
+#   of the License, or (at your option) any later version.
+#
+#   do-mpc is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with do-mpc.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+from casadi import *
+from casadi.tools import *
+import sys
+import time
+import unittest
+
+from importlib import reload
+import copy
+
+do_mpc_path = '../'
+if not do_mpc_path in sys.path:
+    sys.path.append('../')
+
+import do_mpc
+
+
+class TestBatchReactor(unittest.TestCase):
+    def setUp(self):
+        """Add path of test case and import the modules.
+        If this test isn't the first to run, the modules need to be reloaded.
+        Reset path afterwards.
+        """
+        default_path = copy.deepcopy(sys.path)
+        sys.path.append('../examples/batch_reactor/')
+        import template_model
+        import template_mpc
+        import template_simulator
+
+        self.template_model = reload(template_model)
+        self.template_mpc = reload(template_mpc)
+        self.template_simulator = reload(template_simulator)
+        sys.path = default_path
+
+    def test_compiled_vs_not_compiled(self):
+        start_time = time.time()
+        self.batch_reactor(is_compiled=True)
+        end_time = time.time()
+        compiled_time = end_time - start_time
+
+        start_time = time.time()
+        self.batch_reactor(is_compiled=False)
+        end_time = time.time()
+        not_compiled_time = end_time - start_time
+
+        self.assertLess(compiled_time, not_compiled_time)
+
+    def batch_reactor(self, symvar_type="MX", is_compiled=False):
+        """
+        Get configured do-mpc modules:
+        """
+
+        model = self.template_model.template_model(symvar_type)
+        mpc = self.template_mpc.template_mpc(model, silence_solver=True)
+        simulator = self.template_simulator.template_simulator(model)
+        estimator = do_mpc.estimator.StateFeedback(model)
+
+        """
+        Set initial state
+        """
+
+        X_s_0 = 1.0 # This is the initial concentration inside the tank [mol/l]
+        S_s_0 = 0.5 # This is the controlled variable [mol/l]
+        P_s_0 = 0.0 #[C]
+        V_s_0 = 120.0 #[C]
+        x0 = np.array([X_s_0, S_s_0, P_s_0, V_s_0])
+
+        mpc.x0 = x0
+        simulator.x0 = x0
+        estimator.x0 = x0
+
+        mpc.set_initial_guess()
+
+        """
+        Compile the model:
+        """
+
+        if is_compiled:
+            mpc.compile_nlp()
+
+        """
+        Run some steps:
+        """
+
+        for k in range(5):
+            u0 = mpc.make_step(x0)
+            y_next = simulator.make_step(u0)
+            x0 = estimator.make_step(y_next)
+
+        """
+        Store results (for reference run):
+        """
+        # do_mpc.data.save_results([mpc, simulator, estimator], 'results_batch_reactor', overwrite=True)
+
+        """
+        Compare results to reference run:
+        """
+        ref = do_mpc.data.load_results('./results/results_batch_reactor.pkl')
+
+        test = ['_x', '_u', '_time', '_z']
+
+        msg = 'Check if variable {var} for {module} is identical to previous runs: {check}. Max diff is {max_diff:.4E}.'
+        for test_i in test:
+            # Check MPC
+            max_diff = np.max(np.abs(mpc.data.__dict__[test_i] - ref['mpc'].__dict__[test_i]), initial=0)
+            check = max_diff < 1e-8
+            self.assertTrue(check, msg.format(var=test_i, module='MPC', check=check, max_diff=max_diff))
+
+            # Check Simulator
+            max_diff = np.max(np.abs(simulator.data.__dict__[test_i] - ref['simulator'].__dict__[test_i]), initial=0)
+            check = max_diff < 1e-8
+            self.assertTrue(check, msg.format(var=test_i, module='Simulator', check=check, max_diff=max_diff))
+
+            # Estimator
+            max_diff = np.max(np.abs(estimator.data.__dict__[test_i] - ref['estimator'].__dict__[test_i]), initial=0)
+            check = max_diff < 1e-8
+            self.assertTrue(check, msg.format(var=test_i, module='Estimator', check=check, max_diff=max_diff))
+
+
+        """
+        Store results (from reference run):
+        """
+        #do_mpc.data.save_results([mpc, simulator, estimator], 'results_batch_rector')
+
+        # Store for test reasons
+        try:
+            do_mpc.data.save_results([mpc, simulator], 'test_save', overwrite=True)
+        except:
+            raise Exception()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
It seems that `nlpsol` was not imported from casadi and it was used in the source code.

In addition, this feature is not covered by the unit tests and the CI.

I have added a test case based on the other test cases and fixed the bug.

Please run the following command to run the test: (only supported on MacOS and Linux environments)
```
python -m unittest testing/test_batch_reactor_compiled.py
```

The test case checks if the complied MPC is faster and has the same results. (0.2593s to 0.4582s in this example)