### PR TITLE
The bug in _server.py that the default URL is always used has been fixed

### DIFF
--- a/do_mpc/opcua/_helper.py
+++ b/do_mpc/opcua/_helper.py
@@ -83,8 +83,8 @@ class ServerOpts:
 
     Args:
         name : Name of the server.
-        address : IP address of the server.
-        port : Used port number.
+        address : URL of the server <scheme>://<netloc>/<path>;<params>?<query>#<fragment>.
+        port : Used port number (Argument is currently not used).
     '''
     name: str
     address: str
@@ -99,8 +99,8 @@ class ClientOpts:
 
     Args:
         name : Name of the client.
-        address : IP address of the target server.
-        port : Used port number of the target server.
+        address : URL of the target server <scheme>://<netloc>/<path>;<params>?<query>#<fragment>.
+        port : Used port number of the target server (Argument is currently not used).
         timeunit: Time unit factor to convert the time unit used by the dynamic system into seconds. The default value is 1 for seconds. Use 60 for minutes, 3600 for hours, and so on. 
     '''
 
@@ -109,7 +109,7 @@ class ClientOpts:
     """
     name: str
     """
-    IP address of the target server.
+    URL of the target server.
     """
 
     address: str

--- a/do_mpc/opcua/_server.py
+++ b/do_mpc/opcua/_server.py
@@ -75,7 +75,9 @@ class RTServer:
             self.created = False
             print("Server could not be created. Check your opcua module installation!")
             return False
-
+        
+        # Set endpoint (If not specified self.opcua_server.start() will give an error)
+        self.opcua_server.set_endpoint(self.address)
      
     def namespace_from_client(self, client:RTClient)->None:
         '''
@@ -137,7 +139,7 @@ class RTServer:
         try:
             self.opcua_server.start()
 
-        except RuntimeError as err:
+        except Exception as err:
             print("The server "+ self.name +" could not be started, returned error message :\n", err)
 
     


### PR DESCRIPTION
The `address` argument in `ServerOpts` is used to specify the server URL.