### PR TITLE
Bug fix missing opts dict.

### DIFF
--- a/do_mpc/simulator.py
+++ b/do_mpc/simulator.py
@@ -288,6 +288,8 @@ class Simulator(do_mpc.model.IteratedVariables):
                     'abstol': self._settings.abstol,
                     'reltol': self._settings.reltol,
                 }
+            else:
+                opts = {}
 
             # Add further options for the CasADi integrator call defined by the user 
             opts.update(self._settings.integration_opts)


### PR DESCRIPTION
If integration mode collocation is chosen the opts dict is not created due to if condition. Fix: instantiate empty dict.