### PR TITLE
Fix bug in integrator options in simulator.py.

### DIFF
--- a/do_mpc/simulator.py
+++ b/do_mpc/simulator.py
@@ -281,7 +281,7 @@ class Simulator(do_mpc.model.IteratedVariables):
                 'ode': xdot,
                 'alg': alg,
             }
-
+            opts = {}
             # Set the integrator options, note that 'abstol' and 'reltol' are not needed for collocation
             if self._settings.integration_tool != 'collocation':
                 opts = {


### PR DESCRIPTION
The `opts` dict is not defined, when `self._settings.integration_tool != 'collocation'` is set. Thus, `opts` variable is initialized with an empty dict.