### PR TITLE
Revert 468 revert 466 develop: Added variable scaling feature in simulator class

### DIFF
--- a/do_mpc/simulator.py
+++ b/do_mpc/simulator.py
@@ -695,7 +695,8 @@ class Simulator(do_mpc.model.IteratedVariables):
         self.sim_x_num.master = x_new
         self.sim_x_num_unscaled.master = x_new * self._x_scaling.cat
         self.sim_z_num.master = z_new
-        self.sim_z_num_unscaled.master = z_new * self._z_scaling.cat
+        if z_new.shape[0] > 0:
+            self.sim_z_num_unscaled.master = z_new * self._z_scaling.cat
 
         # There may be made an error here. sim_p_num fits to values in time step
         # k + 1 (new). However, the values are actually the p values for step


### PR DESCRIPTION
Depending on the complexity of your model, it can be possible that the casadi integrators such as cvodes and idas can fail when you provide a badly scaled system. The scaling feature can solve potential issues in case that your integration tool fails by enabling manual scaling of the differential and algebraic states.

The scaling feature for the simulator class can be used just like the scaling feature of the optimizer/mpc class.

In addition, a slightly different version of the industrial polymerization reactor example is implemented that considers the adiabatic temperature not as a differential equation but as an algebraic eqution. Running both examples (ode and dae version) delivers the same results.