### PR TITLE
Fix typo: Changes' in documentation

### DIFF
--- a/do_mpc/estimator/_mhe.py
+++ b/do_mpc/estimator/_mhe.py
@@ -902,7 +902,7 @@ class MHE(Optimizer, Estimator):
 
         Warnings:
             Moving horizon estimation will only work reliably once **a full sequence of measurements**
-            corresponding to the set horizon ist available.
+            corresponding to the set horizon is available.
 
         Args:
             y0: Current measurement.


### PR DESCRIPTION
Fixes #525

Corrected typo in mhe.make_step documentation line 905:
- Changed 'ist available' to 'is available'

This fixes the grammatical error in the warning message.